### PR TITLE
Decrypt: Add support for AES-256-CBC

### DIFF
--- a/pkcs7.go
+++ b/pkcs7.go
@@ -353,7 +353,7 @@ func (eci encryptedContentInfo) decrypt(key []byte) ([]byte, error) {
 	}
 
 	iv := eci.ContentEncryptionAlgorithm.Parameters.Bytes
-	if len(iv) != 8 {
+	if len(iv) != block.BlockSize() {
 		return nil, errors.New("pkcs7: encryption algorithm parameters are malformed")
 	}
 	mode := cipher.NewCBCDecrypter(block, iv)


### PR DESCRIPTION
Thanks for the library!

I was trying to parse encrypted yaml files generated by [hiera-eyaml](https://github.com/TomPoulton/hiera-eyaml) so I added AES-256-CBC.