### PR TITLE
Ordering of SignerInfos

### DIFF
--- a/pkcs7.go
+++ b/pkcs7.go
@@ -59,9 +59,9 @@ type signedData struct {
 	Version                    int                        `asn1:"default:1"`
 	DigestAlgorithmIdentifiers []pkix.AlgorithmIdentifier `asn1:"set"`
 	ContentInfo                contentInfo
+	SignerInfos                []signerInfo           `asn1:"set"`
 	Certificates               asn1.RawValue          `asn1:"optional,tag:0"`
 	CRLs                       []pkix.CertificateList `asn1:"optional,tag:1"`
-	SignerInfos                []signerInfo           `asn1:"set"`
 }
 
 type envelopedData struct {


### PR DESCRIPTION
I was trying to parse a pkcs7 signature of an AWS EC2 instance identity document.
The `Parse` method was failing with a tag mismatch error.

After some digging, I realized that the function was expecting a certificate in place of signer information.

I made the below change and am able to successfully parse the signature now.

It would be great if this gets merged.