### PR TITLE
Fixed data truncation for signed messages

### DIFF
--- a/pkcs7.go
+++ b/pkcs7.go
@@ -161,8 +161,6 @@ func parseSignedData(data []byte) (*PKCS7, error) {
 
 	// The Content.Bytes maybe empty on PKI responses.
 	if len(sd.ContentInfo.Content.Bytes) > 0 {
-		var totalBytes []byte
-
 		if _, err := asn1.Unmarshal(sd.ContentInfo.Content.Bytes, &compound); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
I noticed that data gets truncated on signed messages because only the first ASN.1 data structure was parsed. 
The fix now loops over any rest that comes back from ans1.Unmarshal and tries to unmarshal that rest again.