### PR TITLE
correctly marshal degenerate certificates

### DIFF
--- a/pkcs7.go
+++ b/pkcs7.go
@@ -655,23 +655,34 @@ func marshalCertificates(certs []*x509.Certificate) rawCertificates {
 	for _, cert := range certs {
 		buf.Write(cert.Raw)
 	}
-	// Even though, the tag & length are stripped out during marshalling the
-	// RawContent, we have to encode it into the RawContent. If its missing,
-	// then `asn1.Marshal()` will strip out the certificate wrapper instead.
-	var val = asn1.RawValue{Bytes: buf.Bytes(), Class: 2, Tag: 0, IsCompound: true}
-	b, _ := asn1.Marshal(val)
-	return rawCertificates{Raw: b}
+	rawCerts, _ := marshalCertificateBytes(buf.Bytes())
+	return rawCerts
 }
 
-// DegenerateCertificates creates a signed data structure containing only the
-// provided certificates
-func DegenerateCertificates(certs []*x509.Certificate) ([]byte, error) {
-	rawCerts := marshalCertificates(certs)
+// Even though, the tag & length are stripped out during marshalling the
+// RawContent, we have to encode it into the RawContent. If its missing,
+// then `asn1.Marshal()` will strip out the certificate wrapper instead.
+func marshalCertificateBytes(certs []byte) (rawCertificates, error) {
+	var val = asn1.RawValue{Bytes: certs, Class: 2, Tag: 0, IsCompound: true}
+	b, err := asn1.Marshal(val)
+	if err != nil {
+		return rawCertificates{}, err
+	}
+	return rawCertificates{Raw: b}, nil
+}
+
+// DegenerateCertificate creates a signed data structure containing only the
+// provided certificate or certificate chain.
+func DegenerateCertificate(cert []byte) ([]byte, error) {
+	rawCert, err := marshalCertificateBytes(cert)
+	if err != nil {
+		return nil, err
+	}
 	emptyContent := contentInfo{ContentType: oidData}
 	sd := signedData{
 		Version:      1,
 		ContentInfo:  emptyContent,
-		Certificates: rawCerts,
+		Certificates: rawCert,
 		CRLs:         []pkix.CertificateList{},
 	}
 	content, err := asn1.Marshal(sd)

--- a/pkcs7.go
+++ b/pkcs7.go
@@ -663,14 +663,15 @@ func marshalCertificates(certs []*x509.Certificate) rawCertificates {
 	return rawCertificates{Raw: b}
 }
 
-// DegenerateCertificate creates a signed data structure containing only the
-// provided certificate
-func DegenerateCertificate(cert []byte) ([]byte, error) {
+// DegenerateCertificates creates a signed data structure containing only the
+// provided certificates
+func DegenerateCertificates(certs []*x509.Certificate) ([]byte, error) {
+	rawCerts := marshalCertificates(certs)
 	emptyContent := contentInfo{ContentType: oidData}
 	sd := signedData{
 		Version:      1,
 		ContentInfo:  emptyContent,
-		Certificates: rawCertificates{Raw: cert},
+		Certificates: rawCerts,
 		CRLs:         []pkix.CertificateList{},
 	}
 	content, err := asn1.Marshal(sd)

--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -66,7 +66,7 @@ func TestDegenerateCertificate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	deg, err := DegenerateCertificate(cert.Certificate.Raw)
+	deg, err := DegenerateCertificates([]*x509.Certificate{cert.Certificate})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -11,7 +11,10 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math/big"
+	"os"
+	"os/exec"
 	"testing"
 	"time"
 )
@@ -66,11 +69,37 @@ func TestDegenerateCertificate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	deg, err := DegenerateCertificates([]*x509.Certificate{cert.Certificate})
+	deg, err := DegenerateCertificate(cert.Certificate.Raw)
 	if err != nil {
 		t.Fatal(err)
 	}
+	testOpenSSLParse(t, deg)
+
 	fmt.Printf("=== BEGIN DEGENERATE CERT ===\n% X\n=== END DEGENERATE CERT ===\n", deg)
+}
+
+// writes the cert to a temporary file and tests that openssl can read it.
+func testOpenSSLParse(t *testing.T, certBytes []byte) {
+	tmpCertFile, err := ioutil.TempFile("", "testCertificate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpCertFile.Name()) // clean up
+
+	if _, err := tmpCertFile.Write(certBytes); err != nil {
+		t.Fatal(err)
+	}
+
+	opensslCMD := exec.Command("openssl", "pkcs7", "-inform", "der", "-in", tmpCertFile.Name())
+	_, err = opensslCMD.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tmpCertFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
 }
 
 func TestSign(t *testing.T) {


### PR DESCRIPTION
The `marshalCertificates` function introduced in https://github.com/fullsailor/pkcs7/commit/2585af45975b11f1d7502bb6c01556c29efb54ce#diff-f6d905a9fe95414d2307bb69be1c110eR653  addresses the parsing issue introduced in #4, but caused DegenerateCertificate to not marshal the data correctly. 

Additionally, some cases, like SCEP can require that a whole certificate chain to be marshaled as a degenerate SignedData type. 
https://tools.ietf.org/html/draft-gutmann-scep-02#section-5.2.1.1.2

This PR addresses both issues. 
 