### PR TITLE
Support S/MIME detached signatures, and improve tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: go
 
 go:
     - 1.6
+    - 1.7
     - tip

--- a/pkcs7.go
+++ b/pkcs7.go
@@ -649,6 +649,12 @@ func (sd *SignedData) AddCertificate(cert *x509.Certificate) {
 	sd.certs = append(sd.certs, cert)
 }
 
+// Detach removes content from the signed data struct to make it a detached signature.
+// This must be called right before Finish()
+func (sd *SignedData) Detach() {
+	sd.sd.ContentInfo = contentInfo{ContentType: oidSignedData}
+}
+
 // Finish marshals the content and its signers
 func (sd *SignedData) Finish() ([]byte, error) {
 	sd.sd.Certificates = marshalCertificates(sd.certs)


### PR DESCRIPTION
Good day. First of all, thanks for a great little lib, it saved me a whole bunch of time reimplementing pkcs7 in Go. I'd like to use it in [autograph](https://github.com/mozilla-services/autograph) to sign Firefox addons, which use a JAR-type signature, based on pkcs7 S/MIME detached signatures.

Detached signatures are really just the basic SignedData minus the Content field. The new `Detach()` method simply resets the Content field to an empty value.

I also added a few tests, including one that verifies a detached signature using OpenSSL. It required tweaking some of the X.509 fields of the test certificates for it to work.

Next I'll take a look at the `Verify` function to make sure it checks the chain of trust.

Let me know if this is implemented correctly.