### PR TITLE
Encrypt: Add support for AES-256-CBC

### DIFF
--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -251,6 +251,7 @@ func TestEncrypt(t *testing.T) {
 	modes := []int{
 		EncryptionAlgorithmDESCBC,
 		EncryptionAlgorithmAES128GCM,
+		EncryptionAlgorithmAES256CBC,
 	}
 
 	for _, mode := range modes {


### PR DESCRIPTION
Hello, 

Thanks for this awesome module!
As decryption was already added for AES-256-CBC, I now also added encryption support!

This can be selected with the usual `ContentEncryptionAlgorithm` variable.
I also added it to the test suit for verification.
