### PR TITLE
SHA256 as a new default

### DIFF
--- a/pkcs7.go
+++ b/pkcs7.go
@@ -558,9 +558,9 @@ func NewSignedData(data []byte) (*SignedData, error) {
 		Content:     asn1.RawValue{Class: 2, Tag: 0, Bytes: content, IsCompound: true},
 	}
 	digAlg := pkix.AlgorithmIdentifier{
-		Algorithm: oidSHA1,
+		Algorithm: oidSHA256,
 	}
-	h := crypto.SHA1.New()
+	h := crypto.SHA256.New()
 	h.Write(data)
 	md := h.Sum(nil)
 	sd := signedData{
@@ -648,7 +648,7 @@ func (sd *SignedData) AddSigner(cert *x509.Certificate, pkey crypto.PrivateKey, 
 	if err != nil {
 		return err
 	}
-	signature, err := signAttributes(finalAttrs, pkey, crypto.SHA1)
+	signature, err := signAttributes(finalAttrs, pkey, crypto.SHA256)
 	if err != nil {
 		return err
 	}
@@ -660,7 +660,7 @@ func (sd *SignedData) AddSigner(cert *x509.Certificate, pkey crypto.PrivateKey, 
 
 	signer := signerInfo{
 		AuthenticatedAttributes:   finalAttrs,
-		DigestAlgorithm:           pkix.AlgorithmIdentifier{Algorithm: oidSHA1},
+		DigestAlgorithm:           pkix.AlgorithmIdentifier{Algorithm: oidSHA256},
 		DigestEncryptionAlgorithm: pkix.AlgorithmIdentifier{Algorithm: oidRSA},
 		IssuerAndSerialNumber:     ias,
 		EncryptedDigest:           signature,
@@ -718,7 +718,7 @@ func signAttributes(attrs []attribute, pkey crypto.PrivateKey, hash crypto.Hash)
 	hashed := h.Sum(nil)
 	switch priv := pkey.(type) {
 	case *rsa.PrivateKey:
-		return rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA1, hashed)
+		return rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA256, hashed)
 	}
 	return nil, ErrUnsupportedAlgorithm
 }

--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -241,9 +241,12 @@ func TestOpenSSLVerifyDetachedSignature(t *testing.T) {
 		"-content", tmpContentFile.Name(),
 		"-CAfile", tmpRootCertFile.Name())
 	out, err := opensslCMD.Output()
-	t.Logf("%s", out)
+	t.Logf("%q", out)
 	if err != nil {
-		t.Fatalf("openssl command failed with %s", err)
+		t.Errorf("openssl command failed with %s", err)
+		if ee, ok := err.(*exec.ExitError); ok {
+			t.Errorf("stderr output: %q", ee.Stderr)
+		}
 	}
 }
 


### PR DESCRIPTION
Hi Andrew! After the deprecation of sha1 as a default hash algorithm for signing I took a liberty to add sha256, sha384 and sha512 support to your library. It's a simple hack but it'd be nice if you include it into the mainstream version.