### PR TITLE
fixed: hardcoded signature algo

### DIFF
--- a/pkcs7.go
+++ b/pkcs7.go
@@ -254,8 +254,7 @@ func verifySignature(p7 *PKCS7, signer signerInfo) error {
 		return errors.New("pkcs7: No certificate for signer")
 	}
 
-	algo := x509.SHA1WithRSA
-	return cert.CheckSignature(algo, signedData, signer.EncryptedDigest)
+	return cert.CheckSignature(cert.SignatureAlgorithm, signedData, signer.EncryptedDigest)
 }
 
 func marshalAttributes(attrs []attribute) ([]byte, error) {


### PR DESCRIPTION
This patch removes the hardcoded value of the signature verification ago.
This fixes an error that starts to appear in go1.10 