### PR TITLE
verifySignature: always use the certificate's algorithm

### DIFF
--- a/pkcs7.go
+++ b/pkcs7.go
@@ -253,9 +253,7 @@ func verifySignature(p7 *PKCS7, signer signerInfo) error {
 	if cert == nil {
 		return errors.New("pkcs7: No certificate for signer")
 	}
-
-	algo := x509.SHA1WithRSA
-	return cert.CheckSignature(algo, signedData, signer.EncryptedDigest)
+	return cert.CheckSignature(cert.SignatureAlgorithm, signedData, signer.EncryptedDigest)
 }
 
 func marshalAttributes(attrs []attribute) ([]byte, error) {


### PR DESCRIPTION
VerifySignature previously hardcoded x509.SHA1WithRSA as the 
verification signature. As of Go 1.10, the x509 package verifies that 
the requested algorithm matches the certificate's public key type.
VerifySignature would then fail for certificates with DSA keys, such
as AWS's EC2 instance identity documents.

Fix this by always using the certificate's algorithm directly.