### PR TITLE
Add support for verifying SHA256 signer digest

### DIFF
--- a/pkcs7.go
+++ b/pkcs7.go
@@ -301,6 +301,8 @@ func getHashForOID(oid asn1.ObjectIdentifier) (crypto.Hash, error) {
 	switch {
 	case oid.Equal(oidDigestAlgorithmSHA1):
 		return crypto.SHA1, nil
+  case oid.Equal(oidSHA256):
+    return crypto.SHA256, nil
 	}
 	return crypto.Hash(0), ErrUnsupportedAlgorithm
 }


### PR DESCRIPTION
Hi @fullsailor,

I am verifying PKCS #7 data containing a signer with SHA256 digest algorithm.  `verifySignature` fails due to `getHashForOID` requiring SHA1.  This patch would update `getHashForOID` to allow SHA256.

Glad to hear your thoughts on the change.

Thanks!