### PR TITLE
Comment out all lines with encodeIndent variable

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 )
 
-var encodeIndent = 0
+// var encodeIndent = 0
 
 type asn1Object interface {
 	EncodeTo(writer *bytes.Buffer) error
@@ -18,7 +18,7 @@ type asn1Structured struct {
 
 func (s asn1Structured) EncodeTo(out *bytes.Buffer) error {
 	//fmt.Printf("%s--> tag: % X\n", strings.Repeat("| ", encodeIndent), s.tagBytes)
-	encodeIndent++
+	//encodeIndent++
 	inner := new(bytes.Buffer)
 	for _, obj := range s.content {
 		err := obj.EncodeTo(inner)
@@ -26,7 +26,7 @@ func (s asn1Structured) EncodeTo(out *bytes.Buffer) error {
 			return err
 		}
 	}
-	encodeIndent--
+	//encodeIndent--
 	out.Write(s.tagBytes)
 	encodeLength(out, inner.Len())
 	out.Write(inner.Bytes())


### PR DESCRIPTION
There are complaints about data races when `ber2der` is used in multiple goroutines.  Actually, this is because of `encodeIndent` variable which is used only for debugging purpose.