### PR TITLE
Make getHashForOID handle more algorithms

### DIFF
--- a/pkcs7.go
+++ b/pkcs7.go
@@ -301,8 +301,13 @@ func getHashForOID(oid asn1.ObjectIdentifier) (crypto.Hash, error) {
 	switch {
 	case oid.Equal(oidDigestAlgorithmSHA1):
 		return crypto.SHA1, nil
-  case oid.Equal(oidSHA256):
-    return crypto.SHA256, nil
+	case oid.Equal(oidSHA256):
+		return crypto.SHA256, nil
+	}
+	for _, algoDetails := range signatureAlgorithmDetails {
+		if oid.Equal(algoDetails.oid) {
+			return algoDetails.hash, nil
+		}
 	}
 	return crypto.Hash(0), ErrUnsupportedAlgorithm
 }


### PR DESCRIPTION
Specifically, SHA256 and every registered signature algorithms.

Shortcoming of the original version encountered when trying to parse PKCS7 data obtained via the Microsoft Azure VM Instance Metadata service (https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service)