### PR TITLE
Added support for AES256 CBC encryption

### DIFF
--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -251,6 +251,7 @@ func TestEncrypt(t *testing.T) {
 	modes := []int{
 		EncryptionAlgorithmDESCBC,
 		EncryptionAlgorithmAES128GCM,
+		EncryptionAlgorithmAES256CBC,
 	}
 
 	for _, mode := range modes {


### PR DESCRIPTION
I stumbled upon the need for AES256 CBC encryption. This PR adds support for it.

This module is the easiest (if not the only) implementation for working with PKCS#7/CMS enveloped messages in Go I have found so far, so it would be useful to expand it with more algorithms.

Altough there is a similar PR (#22) addressing the same feature, the code in this one is more similar to the other methods (particularly `encryptDESCBC`), which will help to factor out commonalities among them in the future.

Thanks!
